### PR TITLE
Fix reciprocal of a complex number with zero imaginary part

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -638,6 +638,10 @@ IN> z.div(w)
 OUT> {x:0.5588,y:-0.2353}
 IN> z.sub(w)
 OUT> {x:1, y:-4}
+IN> z.reciprocal()
+OUT> {x: 0.12, y: -0.16}
+IN> numeric.t(2, 0).reciprocal()
+OUT> {x: 0.5, y: 0}
 </pre>
 
 Complex vectors and matrices can also be handled:

--- a/src/documentation.html
+++ b/src/documentation.html
@@ -638,6 +638,10 @@ IN> z.div(w)
 OUT> {x:0.5588,y:-0.2353}
 IN> z.sub(w)
 OUT> {x:1, y:-4}
+IN> z.reciprocal()
+OUT> {x: 0.12, y: -0.16}
+IN> numeric.t(2, 0).reciprocal()
+OUT> {x: 0.5, y: 0}
 </pre>
 
 Complex vectors and matrices can also be handled:

--- a/src/numeric.js
+++ b/src/numeric.js
@@ -1071,7 +1071,7 @@ numeric.T.prototype.reciprocal = function reciprocal() {
         var d = numeric.add(mul(this.x,this.x),mul(this.y,this.y));
         return new numeric.T(div(this.x,d),div(numeric.neg(this.y),d));
     }
-    return new T(div(1,this.x));
+    return new numeric.T(div(1,this.x), 0);
 }
 numeric.T.prototype.div = function div(y) {
     if(!(y instanceof numeric.T)) y = new numeric.T(y);


### PR DESCRIPTION
The reciprocal function is broken when applied to a complex number with zero imaginary part. The code path forgot to use a namespace for the result, and also forgot to include the imaginary part of the result. I added a suitable test case to the documentation to check for this. The missing namespace was found by jshint, the missing imaginary part then exposed by the unit test I had added.

I filed this as sloisel/numeric#59 but apparently that repository is largely unmaintained. Yours appears to be in a much better shape.
